### PR TITLE
Update docker-loghose to v1.1.0.

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "docker-allcontainers": "^0.4.0",
     "docker-event-log": "^0.1.2",
-    "docker-loghose": "^0.7.0",
+    "docker-loghose": "^1.1.0",
     "docker-stats": "^0.5.0",
     "dockerode": "^2.2.2",
     "end-of-stream": "^1.1.0",


### PR DESCRIPTION
 Fixes several issues including log truncation.

<0.8.0 messages could be truncated.  See https://github.com/mcollina/docker-loghose/issues/4