### PR TITLE
alpine base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,13 +2,17 @@
 #
 # VERSION 0.2.0
 
-FROM node:0.12-onbuild
+FROM alpine:edge
 MAINTAINER Rapid 7 - Logentries <support@logentries.com>
+
+RUN echo '@edge http://nl.alpinelinux.org/alpine/edge/main' >> /etc/apk/repositories
+RUN apk update && apk upgrade
+RUN apk add nodejs
 
 WORKDIR /usr/src/app
 COPY package.json package.json
 RUN npm install --production
 COPY index.js /usr/src/app/index.js
 
-ENTRYPOINT ["/usr/src/app/index.js"]
+ENTRYPOINT ["node", "/usr/src/app/index.js"]
 CMD []

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 # docker-logentries
 #
-# VERSION 0.2.0
+# VERSION 0.2.1
 
-FROM alpine:edge
+FROM alpine:3.5
 MAINTAINER Rapid 7 - Logentries <support@logentries.com>
 
 RUN echo '@edge http://nl.alpinelinux.org/alpine/edge/main' >> /etc/apk/repositories


### PR DESCRIPTION
@pascalandy what do you think of using this base image to bring the docker-logentries image total  size down to ~43MB. Initial testing has proven stable. Would you mind giving this a try?