### PR TITLE
Fix Unexpected end of input

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,12 +13,12 @@
   "author": "Matteo Collina <matteo.collina@nearform.com>",
   "license": "MIT",
   "dependencies": {
-    "docker-allcontainers": "^0.4.0",
-    "docker-event-log": "^0.1.2",
-    "docker-loghose": "^1.1.0",
-    "docker-stats": "^0.5.0",
-    "dockerode": "^2.2.2",
-    "end-of-stream": "^1.1.0",
+    "docker-allcontainers": "^0.8.0",
+    "docker-event-log": "^0.1.3",
+    "docker-loghose": "^1.6.3",
+    "docker-stats": "^0.8.0",
+    "dockerode": "^2.5.5",
+    "end-of-stream": "^1.4.1",
     "minimist": "^1.1.1",
     "through2": "^0.6.5"
   }


### PR DESCRIPTION
We were getting a lot of these errors in our Kubernetes cluster:

```sh
undefined:1
ly@sha256:1e46371b9c63bcf93d2ef61a0037abecaaacc5cc65f5738108d5e233ada6211a","i
                                                                             ^
SyntaxError: Unexpected token i
    at Object.parse (native)
    at DestroyableTransform._transform (/usr/src/app/node_modules/docker-allcontainers/allcontainers.js:27:21)
    at DestroyableTransform.Transform._read (/usr/src/app/node_modules/through2/node_modules/readable-stream/lib/_stream_transform.js:184:10)
    at DestroyableTransform.Transform._write (/usr/src/app/node_modules/through2/node_modules/readable-stream/lib/_stream_transform.js:172:12)
    at doWrite (/usr/src/app/node_modules/through2/node_modules/readable-stream/lib/_stream_writable.js:237:10)
    at writeOrBuffer (/usr/src/app/node_modules/through2/node_modules/readable-stream/lib/_stream_writable.js:227:5)
    at DestroyableTransform.Writable.write (/usr/src/app/node_modules/through2/node_modules/readable-stream/lib/_stream_writable.js:194:11)
    at write (/usr/src/app/node_modules/through2/node_modules/readable-stream/lib/_stream_readable.js:623:24)
    at flow (/usr/src/app/node_modules/through2/node_modules/readable-stream/lib/_stream_readable.js:632:7)
    at DestroyableTransform.pipeOnReadable (/usr/src/app/node_modules/through2/node_modules/readable-stream/lib/_stream_readable.js:664:5)
undefined:1
o.kubernetes.container.name":"POD","io.kubernetes.docker.type":"podsandbox","i
                                                                             ^
SyntaxError: Unexpected token i
    at Object.parse (native)
    at DestroyableTransform._transform (/usr/src/app/node_modules/docker-allcontainers/allcontainers.js:27:21)
    at DestroyableTransform.Transform._read (/usr/src/app/node_modules/through2/node_modules/readable-stream/lib/_stream_transform.js:184:10)
    at DestroyableTransform.Transform._write (/usr/src/app/node_modules/through2/node_modules/readable-stream/lib/_stream_transform.js:172:12)
    at doWrite (/usr/src/app/node_modules/through2/node_modules/readable-stream/lib/_stream_writable.js:237:10)
    at writeOrBuffer (/usr/src/app/node_modules/through2/node_modules/readable-stream/lib/_stream_writable.js:227:5)
    at DestroyableTransform.Writable.write (/usr/src/app/node_modules/through2/node_modules/readable-stream/lib/_stream_writable.js:194:11)
    at write (/usr/src/app/node_modules/through2/node_modules/readable-stream/lib/_stream_readable.js:623:24)
    at flow (/usr/src/app/node_modules/through2/node_modules/readable-stream/lib/_stream_readable.js:632:7)
    at DestroyableTransform.pipeOnReadable (/usr/src/app/node_modules/through2/node_modules/readable-stream/lib/_stream_readable.js:664:5)
undefined:1
ubernetes.container.terminationMessagePath":"/dev/termination-log","annotation
                                                                    ^
SyntaxError: Unexpected token a
    at Object.parse (native)
    at DestroyableTransform._transform (/usr/src/app/node_modules/docker-allcontainers/allcontainers.js:27:21)
    at DestroyableTransform.Transform._read (/usr/src/app/node_modules/through2/node_modules/readable-stream/lib/_stream_transform.js:184:10)
    at DestroyableTransform.Transform._write (/usr/src/app/node_modules/through2/node_modules/readable-stream/lib/_stream_transform.js:172:12)
    at doWrite (/usr/src/app/node_modules/through2/node_modules/readable-stream/lib/_stream_writable.js:237:10)
    at writeOrBuffer (/usr/src/app/node_modules/through2/node_modules/readable-stream/lib/_stream_writable.js:227:5)
    at DestroyableTransform.Writable.write (/usr/src/app/node_modules/through2/node_modules/readable-stream/lib/_stream_writable.js:194:11)
    at write (/usr/src/app/node_modules/through2/node_modules/readable-stream/lib/_stream_readable.js:623:24)
    at flow (/usr/src/app/node_modules/through2/node_modules/readable-stream/lib/_stream_readable.js:632:7)
    at DestroyableTransform.pipeOnReadable (/usr/src/app/node_modules/through2/node_modules/readable-stream/lib/_stream_readable.js:664:5)
undefined:1
reedge.net/pause-amd64:3.1","Type":"container","Action":"attach","Actor":{"ID"

SyntaxError: Unexpected end of input
    at Object.parse (native)
    at DestroyableTransform._transform (/usr/src/app/node_modules/docker-allcontainers/allcontainers.js:27:21)
    at DestroyableTransform.Transform._read (/usr/src/app/node_modules/through2/node_modules/readable-stream/lib/_stream_transform.js:184:10)
    at DestroyableTransform.Transform._write (/usr/src/app/node_modules/through2/node_modules/readable-stream/lib/_stream_transform.js:172:12)
    at doWrite (/usr/src/app/node_modules/through2/node_modules/readable-stream/lib/_stream_writable.js:237:10)
    at writeOrBuffer (/usr/src/app/node_modules/through2/node_modules/readable-stream/lib/_stream_writable.js:227:5)
    at DestroyableTransform.Writable.write (/usr/src/app/node_modules/through2/node_modules/readable-stream/lib/_stream_writable.js:194:11)
    at write (/usr/src/app/node_modules/through2/node_modules/readable-stream/lib/_stream_readable.js:623:24)
    at flow (/usr/src/app/node_modules/through2/node_modules/readable-stream/lib/_stream_readable.js:632:7)
    at DestroyableTransform.pipeOnReadable (/usr/src/app/node_modules/through2/node_modules/readable-stream/lib/_stream_readable.js:664:5)
undefined:1
e":"ibt-ibt-ist","io.kubernetes.pod.uid":"d64fe93f-64be-11e8-a9c6-000d3aba3890

SyntaxError: Unexpected end of input
    at Object.parse (native)
    at DestroyableTransform._transform (/usr/src/app/node_modules/docker-allcontainers/allcontainers.js:27:21)
    at DestroyableTransform.Transform._read (/usr/src/app/node_modules/through2/node_modules/readable-stream/lib/_stream_transform.js:184:10)
    at DestroyableTransform.Transform._write (/usr/src/app/node_modules/through2/node_modules/readable-stream/lib/_stream_transform.js:172:12)
    at doWrite (/usr/src/app/node_modules/through2/node_modules/readable-stream/lib/_stream_writable.js:237:10)
    at writeOrBuffer (/usr/src/app/node_modules/through2/node_modules/readable-stream/lib/_stream_writable.js:227:5)
    at DestroyableTransform.Writable.write (/usr/src/app/node_modules/through2/node_modules/readable-stream/lib/_stream_writable.js:194:11)
    at write (/usr/src/app/node_modules/through2/node_modules/readable-stream/lib/_stream_readable.js:623:24)
    at flow (/usr/src/app/node_modules/through2/node_modules/readable-stream/lib/_stream_readable.js:632:7)
    at DestroyableTransform.pipeOnReadable (/usr/src/app/node_modules/through2/node_modules/readable-stream/lib/_stream_readable.js:664:5)
undefined:1
tes.container.name":"POD","io.kubernetes.docker.type":"podsandbox","io.kuberne
                                                                    ^
SyntaxError: Unexpected token i
    at Object.parse (native)
    at DestroyableTransform._transform (/usr/src/app/node_modules/docker-allcontainers/allcontainers.js:27:21)
    at DestroyableTransform.Transform._read (/usr/src/app/node_modules/through2/node_modules/readable-stream/lib/_stream_transform.js:184:10)
    at DestroyableTransform.Transform._write (/usr/src/app/node_modules/through2/node_modules/readable-stream/lib/_stream_transform.js:172:12)
    at doWrite (/usr/src/app/node_modules/through2/node_modules/readable-stream/lib/_stream_writable.js:237:10)
    at writeOrBuffer (/usr/src/app/node_modules/through2/node_modules/readable-stream/lib/_stream_writable.js:227:5)
    at DestroyableTransform.Writable.write (/usr/src/app/node_modules/through2/node_modules/readable-stream/lib/_stream_writable.js:194:11)
    at write (/usr/src/app/node_modules/through2/node_modules/readable-stream/lib/_stream_readable.js:623:24)
    at flow (/usr/src/app/node_modules/through2/node_modules/readable-stream/lib/_stream_readable.js:632:7)
    at DestroyableTransform.pipeOnReadable (/usr/src/app/node_modules/through2/node_modules/readable-stream/lib/_stream_readable.js:664:5)
undefined:1
ubernetes.container.terminationMessagePath":"/dev/termination-log","annotation
                                                                    ^
SyntaxError: Unexpected token a
    at Object.parse (native)
    at DestroyableTransform._transform (/usr/src/app/node_modules/docker-allcontainers/allcontainers.js:27:21)
    at DestroyableTransform.Transform._read (/usr/src/app/node_modules/through2/node_modules/readable-stream/lib/_stream_transform.js:184:10)
    at DestroyableTransform.Transform._write (/usr/src/app/node_modules/through2/node_modules/readable-stream/lib/_stream_transform.js:172:12)
    at doWrite (/usr/src/app/node_modules/through2/node_modules/readable-stream/lib/_stream_writable.js:237:10)
    at writeOrBuffer (/usr/src/app/node_modules/through2/node_modules/readable-stream/lib/_stream_writable.js:227:5)
    at DestroyableTransform.Writable.write (/usr/src/app/node_modules/through2/node_modules/readable-stream/lib/_stream_writable.js:194:11)
    at write (/usr/src/app/node_modules/through2/node_modules/readable-stream/lib/_stream_readable.js:623:24)
    at flow (/usr/src/app/node_modules/through2/node_modules/readable-stream/lib/_stream_readable.js:632:7)
    at DestroyableTransform.pipeOnReadable (/usr/src/app/node_modules/through2/node_modules/readable-stream/lib/_stream_readable.js:664:5)
```

I suspected it was due to this issue on the `end-of-stream` dependency:
https://github.com/mafintosh/end-of-stream/issues/14

The PR upgrades `end-of-stream` dependency to a recent version. Also noticed that pretty much all packages are out of date, so went ahead and did an upgrade to all of them.

Its been running fine with this change on our kubernetes cluster.