### PR TITLE
[LOG-13336] Add more secure default run parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,12 +15,26 @@ The simplest way to forward all your container's log to Logentries is to
 run this repository as a container, with:
 
 ```sh
-docker run -v /var/run/docker.sock:/var/run/docker.sock logentries/docker-logentries -t <TOKEN> -j -a host=`uname -n`
+docker run -v /var/run/docker.sock:/var/run/docker.sock \
+           --read-only \
+           --security-opt=no-new-privileges \
+           logentries/docker-logentries \
+           -t <TOKEN> \
+           -j \
+           -a host=`uname -n`
 ```
 
 You can also use different tokens for logging, stats and events:
 ```sh
-docker run -v /var/run/docker.sock:/var/run/docker.sock logentries/docker-logentries -l <LOGSTOKEN> -k <STATSTOKEN> -e <EVENTSTOKEN> -j -a host=`uname -n`
+docker run -v /var/run/docker.sock:/var/run/docker.sock \
+           --read-only \
+           --security-opt=no-new-privileges \
+           logentries/docker-logentries \
+           -l <LOGSTOKEN> \
+           -k <STATSTOKEN> \
+           -e <EVENTSTOKEN> \
+           -j \
+           -a host=`uname -n`
 ```
 
 You can pass the `--no-stats` flag if you do not want stats to be
@@ -50,7 +64,14 @@ To run the container in such environments add --privileged to the `docker run` c
 
 Example:
 ```sh
-docker run --privileged -v /var/run/docker.sock:/var/run/docker.sock logentries/docker-logentries -t <TOKEN> -j -a host=`uname -n`
+docker run --privileged \
+           -v /var/run/docker.sock:/var/run/docker.sock \
+           --read-only \
+           --security-opt=no-new-privileges \
+           logentries/docker-logentries \
+           -t <TOKEN> \
+           -j \
+           -a host=`uname -n`
 ```
 
 ## Usage as a CLI
@@ -121,7 +142,14 @@ First clone this repository, then:
 
 ```bash
 docker build -t logentries .
-docker run -v /var/run/docker.sock:/var/run/docker.sock logentries -t <TOKEN> -j -a host=`uname -n`
+
+docker run -v /var/run/docker.sock:/var/run/docker.sock \
+           --read-only \
+           --security-opt=no-new-privileges \
+           logentries \
+           -t <TOKEN> \
+           -j \
+           -a host=`uname -n`
 ```
 ### Using Make - the official nodejs onbuild image 
 ```bash

--- a/README.md
+++ b/README.md
@@ -37,6 +37,13 @@ docker run -v /var/run/docker.sock:/var/run/docker.sock \
            -a host=`uname -n`
 ```
 
+The `--read-only` docker flag specifies that the container file system will be read-only.
+This is not a requirement but since currently there's no need for writing, it makes the container more secure.
+
+The `--security-opt=no-new-privileges` docker flag sets a kernel bit which stops the process or its children
+from gaining additional privileges via setuid or sgid.  
+Once again not required, but increases security.
+
 You can pass the `--no-stats` flag if you do not want stats to be
 published to Logentries every second. You __need this flag for Docker
 version < 1.5__.


### PR DESCRIPTION
## Description
<!-- Describe what this change does and why it is needed. -->
Address possible security issues within the logging container.
- (CIS_Docker_CE_v1.1.0 - 5.12) Mount container's root filesystem as read only
- (CIS_Docker_CE_v1.1.0 - 5.25) Restrict container from acquiring additional privileges

## Testing
<!-- Describe how this change was tested -->
Container runs and streams logs to logentries with new flags.