### PR TITLE
Release docker image for arm64.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,38 @@
+name: ci
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+    tags:
+      - v*
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Prepare
+        id: prepare
+        run: |
+            TAG=${GITHUB_REF##*/}
+            echo ::set-output name=tag_name::${TAG}
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Login do docker.io
+        run: docker login -u logentries -p ${{ secrets.DOCKER_TOKEN }}
+      - name: build and publish image
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            logentries/docker-logentries:${{ steps.prepare.outputs.tag_name }}
+            logentries/docker-logentries:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 #
 # VERSION 0.2.0
 
-FROM node:0.12-onbuild
+FROM node:8.17.0-onbuild
 MAINTAINER Rapid 7 - InsightOps <InsightOpsTeam@rapid7.com>
 
 WORKDIR /usr/src/app


### PR DESCRIPTION
The following file has been created and modified:
Added .github/workflows/ci.yml file to build and push the image for both amd64 and arm64 platforms.
Dockerfile: Base image is updated from node:0.12-onbuild to node:lts-alpine3.14 as node:lts-alpine3.14 has arm64 support present in it.

Signed-off-by: odidev odidev@puresoftware.com